### PR TITLE
log errors opening files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ description = "Convert SVG files to PicoSVG."
 
 [dependencies]
 clap = { version = "3.1.8", features = ["cargo"] }
+log = "0.4"
+env_logger = "0.9"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,12 @@ mod path_arg;
 
 use crate::path_arg::PathArg;
 use clap::{arg, command};
+use log::{error, info};
+use std::fs::File;
 
 fn main() {
+    env_logger::init();
+
     // version and about are picked up from Cargo.toml by the command! macro
     let matches = command!()
         .arg_required_else_help(true)
@@ -29,12 +33,28 @@ fn main() {
         unreachable!("Input required, otherwise help should be printed.")
     };
 
+    println!("input {}: {}", input.type_as_string(), input);
+
+    if !input.exists() {
+        error!("Input does not exist: {}", input);
+        return;
+    }
+
+    if input.is_file() {
+        match File::open(input.inner()) {
+            Ok(_) => info!("opened file: {}", input),
+            Err(err) => {
+                error!("error opening file: {}", err);
+                return;
+            }
+        }
+    }
+
     let output: PathArg = if let Some(out) = matches.value_of_os("output") {
         out.into()
     } else {
         unreachable!("Output required, otherwise help should be printed.")
     };
 
-    println!("input {}: {}", input.type_as_string(), input);
     println!("expected output {}: {}", output.type_as_string(), output);
 }

--- a/src/path_arg.rs
+++ b/src/path_arg.rs
@@ -27,6 +27,14 @@ impl PathArg {
         }
     }
 
+    pub fn exists(&self) -> bool {
+        self.inner().exists()
+    }
+
+    pub fn is_file(&self) -> bool {
+        matches!(self, PathArg::File(_))
+    }
+
     pub fn type_as_string(&self) -> String {
         match self {
             PathArg::File(_) => "file".into(),


### PR DESCRIPTION
Use env_logger to print an error and exit if the input directory or file does not exist or cannot be read.

Not entirely sure how to test this properly. 